### PR TITLE
fix: no search result text in commands menu

### DIFF
--- a/packages/editor/src/extensions/commands-menu/CommandsView.vue
+++ b/packages/editor/src/extensions/commands-menu/CommandsView.vue
@@ -103,7 +103,7 @@ defineExpose({
     </template>
     <div v-else class="command-empty">
       <span>
-        {{ i18n.global.t("core.extensions.commands_menu.no_results") }}
+        {{ i18n.global.t("editor.extensions.commands_menu.no_results") }}
       </span>
     </div>
   </div>


### PR DESCRIPTION
修复当命令面板无搜索结果时，提示文案的 i18n key 取值错误导致无法正常渲染文字的问题。

/kind bug

```release-note
修复当命令面板无搜索结果时，提示文案的 i18n key 取值错误导致无法正常渲染文字的问题。
```