### PR TITLE
fix: image size is changed after loading the content

### DIFF
--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -66,9 +66,16 @@ const height = computed({
 
 const resizeRef = ref<HTMLElement>();
 
+let mounted = false;
+
 const reuseResizeObserver = () => {
   let init = true;
   return useResizeObserver(resizeRef, (entries) => {
+    // Skip first call
+    if (!mounted) {
+      mounted = true;
+      return;
+    }
     if (init) {
       init = false;
       return;

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -2,7 +2,7 @@
 import type { Node as ProseMirrorNode } from "prosemirror-model";
 import type { Decoration } from "prosemirror-view";
 import { Editor, NodeViewWrapper, Node } from "@tiptap/vue-3";
-import { computed } from "vue";
+import { computed, onUnmounted } from "vue";
 import BlockCard from "@/components/block/BlockCard.vue";
 import BlockActionButton from "@/components/block/BlockActionButton.vue";
 import BlockActionSeparator from "@/components/block/BlockActionSeparator.vue";
@@ -70,23 +70,38 @@ let mounted = false;
 
 const reuseResizeObserver = () => {
   let init = true;
-  return useResizeObserver(resizeRef, (entries) => {
-    // Skip first call
-    if (!mounted) {
-      mounted = true;
-      return;
-    }
-    if (init) {
-      init = false;
-      return;
-    }
-    const entry = entries[0];
-    const { width, height } = entry.contentRect;
-    props.updateAttributes({ width: width + "px", height: height + "px" });
-  });
+  return useResizeObserver(
+    resizeRef,
+    (entries) => {
+      // Skip first call
+      if (!mounted) {
+        mounted = true;
+        return;
+      }
+      if (init) {
+        init = false;
+        return;
+      }
+      const entry = entries[0];
+      const { width, height } = entry.contentRect;
+      props.updateAttributes({ width: width + "px", height: height + "px" });
+    },
+    { box: "border-box" }
+  );
 };
 
 let resizeObserver = reuseResizeObserver();
+
+window.addEventListener("resize", resetResizeObserver);
+
+onUnmounted(() => {
+  window.removeEventListener("resize", resetResizeObserver);
+});
+
+function resetResizeObserver() {
+  resizeObserver.stop();
+  resizeObserver = reuseResizeObserver();
+}
 
 function handleSetSize(width: string, height: string) {
   resizeObserver.stop();

--- a/packages/editor/src/extensions/image/index.ts
+++ b/packages/editor/src/extensions/image/index.ts
@@ -17,7 +17,6 @@ const Image = TiptapImage.extend({
       width: {
         default: "100%",
         parseHTML: (element) => {
-          console.log(element);
           const width =
             element.getAttribute("width") || element.style.width || null;
           return width;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

修复编辑文章时，图片的尺寸被修改为元素实际尺寸的问题，导致原本的相对大小（百分比或者 auto）失效。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4215

#### Special notes for your reviewer:

需要测试：

1. 粘贴一个图片，并设置为 100% 的长宽。
2. 刷新页面，查看图片的长宽值是否被改变。

#### Does this PR introduce a user-facing change?

```release-note
修复编辑文章时，图片的尺寸被修改为元素实际尺寸的问题
```
