### PR TITLE
feat: add toolbox for editor header

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -20,6 +20,9 @@
       getCommandMenuItems() {
         return [];
       },
+      getToolboxItems({ editor }: { editor: Editor }) {
+        return []
+      }
     };
   },
 }
@@ -30,6 +33,7 @@
 - `getToolbarItems`：工具栏
 - `getBubbleItems`：悬浮工具栏
 - `getCommandMenuItems`：Slash Command
+- `getToolboxItems`：工具箱（Toolbox）
 
 对应的返回类型为：
 
@@ -70,6 +74,19 @@ export interface CommandMenuItem {
   title: string;
   keywords: string[];
   command: ({ editor, range }: { editor: Editor; range: Range }) => void;
+}
+
+// 工具箱（Toolbox）
+export interface ToolboxItem {
+  priority: number;
+  component: Component;
+  props: {
+    editor: Editor;
+    icon?: Component;
+    title?: string;
+    description?: string;
+    action?: () => void;
+  };
 }
 ```
 

--- a/packages/editor/src/components/EditorHeader.vue
+++ b/packages/editor/src/components/EditorHeader.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import { Menu as VMenu } from "floating-vue";
 import { Editor, type AnyExtension } from "@tiptap/vue-3";
-import type { ToolbarItem } from "@/types";
+import MdiPlusCircle from "~icons/mdi/plus-circle";
+import type { ToolbarItem, ToolboxItem } from "@/types";
 
 const props = defineProps({
   editor: {
@@ -32,11 +33,54 @@ function getToolbarItemsFromExtensions() {
     }, [])
     .sort((a, b) => a.priority - b.priority);
 }
+
+function getToolboxItemsFromExtensions() {
+  const extensionManager = props.editor?.extensionManager;
+  return extensionManager.extensions
+    .reduce((acc: ToolboxItem[], extension: AnyExtension) => {
+      const { getToolboxItems } = extension.options;
+
+      if (!getToolboxItems) {
+        return acc;
+      }
+
+      const items = getToolboxItems({
+        editor: props.editor,
+      });
+
+      if (Array.isArray(items)) {
+        return [...acc, ...items];
+      }
+
+      return [...acc, items];
+    }, [])
+    .sort((a, b) => a.priority - b.priority);
+}
 </script>
 <template>
   <div
-    class="editor-header flex items-center py-1 space-x-0.5 justify-center border-b drop-shadow-sm bg-white"
+    class="editor-header flex items-center py-1 space-x-0.5 justify-start px-1 overflow-auto sm:justify-center border-b drop-shadow-sm bg-white"
   >
+    <div class="inline-flex items-center justify-center">
+      <VMenu>
+        <button class="p-1 rounded-sm hover:bg-gray-100">
+          <MdiPlusCircle class="text-[#4CCBA0]" />
+        </button>
+        <template #popper>
+          <div
+            class="relative rounded-md bg-white overflow-hidden drop-shadow w-56 p-1 max-h-96 overflow-y-auto space-y-1.5"
+          >
+            <component
+              :is="toolboxItem.component"
+              v-for="(toolboxItem, index) in getToolboxItemsFromExtensions()"
+              v-bind="toolboxItem.props"
+              :key="index"
+            />
+          </div>
+        </template>
+      </VMenu>
+    </div>
+    <div class="h-5 bg-gray-100 w-[1px] !mx-1"></div>
     <div
       v-for="(item, index) in getToolbarItemsFromExtensions()"
       :key="index"

--- a/packages/editor/src/components/index.ts
+++ b/packages/editor/src/components/index.ts
@@ -10,3 +10,6 @@ export { default as BubbleItem } from "./bubble/BubbleItem.vue";
 // toolbar
 export { default as ToolbarItem } from "./toolbar/ToolbarItem.vue";
 export { default as ToolbarSubItem } from "./toolbar/ToolbarSubItem.vue";
+
+// toolbox
+export { default as ToolboxItem } from "./toolbox/ToolboxItem.vue";

--- a/packages/editor/src/components/toolbox/ToolboxItem.vue
+++ b/packages/editor/src/components/toolbox/ToolboxItem.vue
@@ -1,0 +1,47 @@
+<script lang="ts" setup>
+import type { Component } from "vue";
+import type { Editor } from "@tiptap/vue-3";
+
+const props = withDefaults(
+  defineProps<{
+    editor?: Editor;
+    title?: string;
+    description?: string;
+    action?: () => void;
+    icon?: Component;
+  }>(),
+  {
+    editor: undefined,
+    title: undefined,
+    description: undefined,
+    action: undefined,
+    icon: undefined,
+  }
+);
+
+const action = () => {
+  props.action?.();
+};
+</script>
+
+<template>
+  <div
+    class="flex flex-row items-center rounded gap-3 py-1 px-1.5 group cursor-pointer hover:bg-gray-100"
+    @click="action"
+  >
+    <component
+      :is="icon"
+      class="bg-gray-100 p-1.5 rounded w-7 h-7 group-hover:bg-white"
+    />
+    <div class="flex flex-col gap-0.5">
+      <span
+        class="text-sm text-gray-600 group-hover:font-medium group-hover:text-gray-900"
+      >
+        {{ title }}
+      </span>
+      <span v-if="description" class="text-xs text-gray-500">
+        {{ description }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/packages/editor/src/extensions/audio/index.ts
+++ b/packages/editor/src/extensions/audio/index.ts
@@ -10,6 +10,8 @@ import { VueNodeViewRenderer } from "@tiptap/vue-3";
 import { markRaw } from "vue";
 import AudioView from "./AudioView.vue";
 import MdiMusicCircleOutline from "~icons/mdi/music-circle-outline";
+import ToolboxItem from "@/components/toolbox/ToolboxItem.vue";
+import { i18n } from "@/locales";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -137,6 +139,26 @@ const Audio = Node.create<ExtensionOptions>({
               .run();
           },
         };
+      },
+      getToolboxItems({ editor }: { editor: Editor }) {
+        return [
+          {
+            priority: 20,
+            component: markRaw(ToolboxItem),
+            props: {
+              editor,
+              icon: markRaw(MdiMusicCircleOutline),
+              title: i18n.global.t("editor.extensions.commands_menu.audio"),
+              action: () => {
+                editor
+                  .chain()
+                  .focus()
+                  .insertContent([{ type: "audio", attrs: { src: "" } }])
+                  .run();
+              },
+            },
+          },
+        ];
       },
     };
   },

--- a/packages/editor/src/extensions/code-block/code-block.ts
+++ b/packages/editor/src/extensions/code-block/code-block.ts
@@ -8,6 +8,7 @@ import { markRaw } from "vue";
 import { i18n } from "@/locales";
 import type { ExtensionOptions } from "@/types";
 import BubbleItem from "@/components/bubble/BubbleItem.vue";
+import ToolboxItem from "@/components/toolbox/ToolboxItem.vue";
 
 export default CodeBlockLowlight.extend<
   ExtensionOptions & CodeBlockLowlightOptions
@@ -54,6 +55,22 @@ export default CodeBlockLowlight.extend<
             editor.chain().focus().deleteRange(range).setCodeBlock().run();
           },
         };
+      },
+      getToolboxItems({ editor }: { editor: Editor }) {
+        return [
+          {
+            priority: 50,
+            component: markRaw(ToolboxItem),
+            props: {
+              editor,
+              icon: markRaw(MdiCodeBracesBox),
+              title: i18n.global.t("editor.common.codeblock"),
+              action: () => {
+                editor.chain().focus().setCodeBlock().run();
+              },
+            },
+          },
+        ];
       },
     };
   },

--- a/packages/editor/src/extensions/iframe/index.ts
+++ b/packages/editor/src/extensions/iframe/index.ts
@@ -11,6 +11,8 @@ import { VueNodeViewRenderer } from "@tiptap/vue-3";
 import { markRaw } from "vue";
 import IframeView from "./IframeView.vue";
 import MdiWeb from "~icons/mdi/web";
+import ToolboxItem from "@/components/toolbox/ToolboxItem.vue";
+import { i18n } from "@/locales";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -204,6 +206,26 @@ const Iframe = Node.create<ExtensionOptions>({
               .run();
           },
         };
+      },
+      getToolboxItems({ editor }: { editor: Editor }) {
+        return [
+          {
+            priority: 40,
+            component: markRaw(ToolboxItem),
+            props: {
+              editor,
+              icon: markRaw(MdiWeb),
+              title: i18n.global.t("editor.extensions.commands_menu.iframe"),
+              action: () => {
+                editor
+                  .chain()
+                  .focus()
+                  .insertContent([{ type: "iframe", attrs: { src: "" } }])
+                  .run();
+              },
+            },
+          },
+        ];
       },
     };
   },

--- a/packages/editor/src/extensions/image/index.ts
+++ b/packages/editor/src/extensions/image/index.ts
@@ -1,8 +1,15 @@
 import TiptapImage from "@tiptap/extension-image";
 import { VueNodeViewRenderer } from "@tiptap/vue-3";
 import ImageView from "./ImageView.vue";
+import type { ImageOptions } from "@tiptap/extension-image";
+import type { ExtensionOptions } from "@/types";
+import type { Editor } from "@tiptap/vue-3";
+import ToolboxItem from "@/components/toolbox/ToolboxItem.vue";
+import MdiFileImageBox from "~icons/mdi/file-image-box";
+import { markRaw } from "vue";
+import { i18n } from "@/locales";
 
-const Image = TiptapImage.extend({
+const Image = TiptapImage.extend<ExtensionOptions & ImageOptions>({
   inline() {
     return true;
   },
@@ -62,6 +69,32 @@ const Image = TiptapImage.extend({
           : 'img[src]:not([src^="data:"])',
       },
     ];
+  },
+
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      getToolboxItems({ editor }: { editor: Editor }) {
+        return [
+          {
+            priority: 10,
+            component: markRaw(ToolboxItem),
+            props: {
+              editor,
+              icon: markRaw(MdiFileImageBox),
+              title: i18n.global.t("editor.common.image"),
+              action: () => {
+                editor
+                  .chain()
+                  .focus()
+                  .insertContent([{ type: "image", attrs: { src: "" } }])
+                  .run();
+              },
+            },
+          },
+        ];
+      },
+    };
   },
 });
 

--- a/packages/editor/src/extensions/video/index.ts
+++ b/packages/editor/src/extensions/video/index.ts
@@ -10,6 +10,8 @@ import { VueNodeViewRenderer } from "@tiptap/vue-3";
 import { markRaw } from "vue";
 import VideoView from "./VideoView.vue";
 import MdiVideo from "~icons/mdi/video";
+import ToolboxItem from "@/components/toolbox/ToolboxItem.vue";
+import { i18n } from "@/locales";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -159,6 +161,26 @@ const Video = Node.create<ExtensionOptions>({
               .run();
           },
         };
+      },
+      getToolboxItems({ editor }: { editor: Editor }) {
+        return [
+          {
+            priority: 20,
+            component: markRaw(ToolboxItem),
+            props: {
+              editor,
+              icon: markRaw(MdiVideo),
+              title: i18n.global.t("editor.extensions.commands_menu.video"),
+              action: () => {
+                editor
+                  .chain()
+                  .focus()
+                  .insertContent([{ type: "video", attrs: { src: "" } }])
+                  .run();
+              },
+            },
+          },
+        ];
       },
     };
   },

--- a/packages/editor/src/locales/en.yaml
+++ b/packages/editor/src/locales/en.yaml
@@ -78,6 +78,7 @@ editor:
     superscript: Super Script
     subscript: Sub Script
     codeblock: Code block
+    image: Image
     heading:
       title: Text type
       paragraph: Paragraph

--- a/packages/editor/src/locales/zh-CN.yaml
+++ b/packages/editor/src/locales/zh-CN.yaml
@@ -78,6 +78,7 @@ editor:
     superscript: 上角标
     subscript: 下角标
     codeblock: 代码块
+    image: 图片
     heading:
       title: 文本类型
       paragraph: 普通文本

--- a/packages/editor/src/types/index.ts
+++ b/packages/editor/src/types/index.ts
@@ -28,6 +28,18 @@ export interface BubbleItem {
   };
 }
 
+export interface ToolboxItem {
+  priority: number;
+  component: Component;
+  props: {
+    editor: Editor;
+    icon?: Component;
+    title?: string;
+    description?: string;
+    action?: () => void;
+  };
+}
+
 export interface ExtensionOptions {
   getToolbarItems?: ({
     editor,
@@ -42,6 +54,12 @@ export interface ExtensionOptions {
   }: {
     editor: Editor;
   }) => BubbleItem | BubbleItem[];
+
+  getToolboxItems?: ({
+    editor,
+  }: {
+    editor: Editor;
+  }) => ToolboxItem | ToolboxItem[];
 }
 
 export interface CommandMenuItem {


### PR DESCRIPTION
在工具栏开头添加 ToolBox 下拉框，用于插件扩展 Block 插入入口。

<img width="1393" alt="image" src="https://github.com/halo-sigs/richtext-editor/assets/21301288/2d1a7e77-7b1b-48e1-b199-5e6f86880c55">

Fixes https://github.com/halo-sigs/richtext-editor/issues/20

/kind feature

```release-note
工具栏支持 Toolbox 下拉框
```