### PR TITLE
fix: content overflow

### DIFF
--- a/packages/editor/src/components/block/BlockCard.vue
+++ b/packages/editor/src/components/block/BlockCard.vue
@@ -73,7 +73,7 @@ function handleInsertNewLine() {
 
 <style lang="scss">
 .editor-block {
-  @apply relative;
+  @apply relative my-9;
 
   &__content {
     @apply transition-all

--- a/packages/editor/src/styles/index.scss
+++ b/packages/editor/src/styles/index.scss
@@ -13,6 +13,7 @@
 
     .ProseMirror {
       height: 100%;
+      overflow: auto;
 
       p.is-empty::before {
         content: attr(data-placeholder);


### PR DESCRIPTION
修复在 Halo 的 Console 中内容溢出的问题。

<img width="1762" alt="image" src="https://github.com/halo-sigs/richtext-editor/assets/21301288/5cbbedff-68df-492d-86cd-557c06b18d78">

/kind bug

```release-note
None
```