### PR TITLE
feat: add change image alt supports

### DIFF
--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -18,7 +18,7 @@ import MdiFormatAlignRight from "~icons/mdi/format-align-right";
 import MdiImageSizeSelectActual from "~icons/mdi/image-size-select-actual";
 import MdiImageSizeSelectLarge from "~icons/mdi/image-size-select-large";
 import MdiImageSizeSelectSmall from "~icons/mdi/image-size-select-small";
-import MdLink from "~icons/mdi/text-box-edit-outline";
+import MdiTextBoxEditOutline from "~icons/mdi/text-box-edit-outline";
 import MdiLinkVariant from "~icons/mdi/link-variant";
 import MdiShare from "~icons/mdi/share";
 

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -1,26 +1,26 @@
 <script lang="ts" setup>
+import BlockActionButton from "@/components/block/BlockActionButton.vue";
+import BlockActionInput from "@/components/block/BlockActionInput.vue";
+import BlockActionSeparator from "@/components/block/BlockActionSeparator.vue";
+import BlockCard from "@/components/block/BlockCard.vue";
+import { i18n } from "@/locales";
+import { Editor, Node, NodeViewWrapper } from "@tiptap/vue-3";
+import { useResizeObserver } from "@vueuse/core";
+import { Dropdown as VDropdown } from "floating-vue";
 import type { Node as ProseMirrorNode } from "prosemirror-model";
 import type { Decoration } from "prosemirror-view";
-import { Editor, NodeViewWrapper, Node } from "@tiptap/vue-3";
-import { computed, onMounted, onUnmounted } from "vue";
-import BlockCard from "@/components/block/BlockCard.vue";
-import BlockActionButton from "@/components/block/BlockActionButton.vue";
-import BlockActionSeparator from "@/components/block/BlockActionSeparator.vue";
-import BlockActionInput from "@/components/block/BlockActionInput.vue";
-import { Dropdown as VDropdown } from "floating-vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import MdiBackupRestore from "~icons/mdi/backup-restore";
+import MdiFormatAlignCenter from "~icons/mdi/format-align-center";
+import MdiFormatAlignJustify from "~icons/mdi/format-align-justify";
+import MdiFormatAlignLeft from "~icons/mdi/format-align-left";
+import MdiFormatAlignRight from "~icons/mdi/format-align-right";
+import MdiImageSizeSelectActual from "~icons/mdi/image-size-select-actual";
+import MdiImageSizeSelectLarge from "~icons/mdi/image-size-select-large";
+import MdiImageSizeSelectSmall from "~icons/mdi/image-size-select-small";
+import MdLink from "~icons/mdi/link";
 import MdiLinkVariant from "~icons/mdi/link-variant";
 import MdiShare from "~icons/mdi/share";
-import MdiImageSizeSelectActual from "~icons/mdi/image-size-select-actual";
-import MdiImageSizeSelectSmall from "~icons/mdi/image-size-select-small";
-import MdiImageSizeSelectLarge from "~icons/mdi/image-size-select-large";
-import MdiFormatAlignLeft from "~icons/mdi/format-align-left";
-import MdiFormatAlignCenter from "~icons/mdi/format-align-center";
-import MdiFormatAlignRight from "~icons/mdi/format-align-right";
-import MdiFormatAlignJustify from "~icons/mdi/format-align-justify";
-import MdiBackupRestore from "~icons/mdi/backup-restore";
-import { i18n } from "@/locales";
-import { useResizeObserver } from "@vueuse/core";
-import { ref } from "vue";
 
 const props = defineProps<{
   editor: Editor;
@@ -292,6 +292,30 @@ onMounted(() => {
             <MdiShare />
           </template>
         </BlockActionButton>
+
+        <VDropdown class="inline-flex" :triggers="['click']" :distance="10">
+          <BlockActionButton
+            :tooltip="i18n.global.t('editor.extensions.image.edit_alt')"
+          >
+            <template #icon>
+              <MdLink />
+            </template>
+          </BlockActionButton>
+
+          <template #popper>
+            <div
+              class="relative rounded-md bg-white overflow-hidden drop-shadow w-96 p-1 max-h-72 overflow-y-auto"
+            >
+              <input
+                v-model.lazy="alt"
+                :placeholder="
+                  i18n.global.t('editor.common.placeholder.alt_input')
+                "
+                class="bg-gray-50 rounded-md hover:bg-gray-100 block px-2 w-full py-1.5 text-sm text-gray-900 border border-gray-300 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          </template>
+        </VDropdown>
       </template>
     </block-card>
   </node-view-wrapper>

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -298,7 +298,7 @@ onMounted(() => {
             :tooltip="i18n.global.t('editor.extensions.image.edit_alt')"
           >
             <template #icon>
-              <MdLink />
+              <MdiTextBoxEditOutline />
             </template>
           </BlockActionButton>
 

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -18,7 +18,7 @@ import MdiFormatAlignRight from "~icons/mdi/format-align-right";
 import MdiImageSizeSelectActual from "~icons/mdi/image-size-select-actual";
 import MdiImageSizeSelectLarge from "~icons/mdi/image-size-select-large";
 import MdiImageSizeSelectSmall from "~icons/mdi/image-size-select-small";
-import MdLink from "~icons/mdi/link";
+import MdLink from "~icons/mdi/text-box-edit-outline";
 import MdiLinkVariant from "~icons/mdi/link-variant";
 import MdiShare from "~icons/mdi/share";
 

--- a/packages/editor/src/locales/en.yaml
+++ b/packages/editor/src/locales/en.yaml
@@ -49,6 +49,7 @@ editor:
       large_size: Large size
       restore_size: Restore original size
       edit_link: Edit link
+      edit_alt: Edit alt
     video:
       disable_controls: Hide controls
       enable_controls: Show controls
@@ -99,6 +100,7 @@ editor:
       open_link: Open link
     placeholder:
       link_input: Enter the link and press enter to confirm.
+      alt_input: Enter the img alt and press enter to confirm.
     button:
       new_line: New line
       delete: Delete

--- a/packages/editor/src/locales/en.yaml
+++ b/packages/editor/src/locales/en.yaml
@@ -100,7 +100,7 @@ editor:
       open_link: Open link
     placeholder:
       link_input: Enter the link and press enter to confirm.
-      alt_input: Enter the img alt and press enter to confirm.
+      alt_input: Enter the image alt and press enter to confirm.
     button:
       new_line: New line
       delete: Delete

--- a/packages/editor/src/locales/zh-CN.yaml
+++ b/packages/editor/src/locales/zh-CN.yaml
@@ -100,7 +100,7 @@ editor:
       open_link: 打开链接
     placeholder:
       link_input: 输入链接，按回车确定
-      alt_input: 输入图片alt属性值,然后回车确认
+      alt_input: 输入图片 alt 属性值，按回车确认
     button:
       new_line: 换行
       delete: 删除

--- a/packages/editor/src/locales/zh-CN.yaml
+++ b/packages/editor/src/locales/zh-CN.yaml
@@ -49,7 +49,7 @@ editor:
       large_size: 大尺寸
       restore_size: 恢复原始尺寸
       edit_link: 修改链接
-      edit_alt: 修改图片alt属性
+      edit_alt: 修改图片 alt 属性
     video:
       disable_controls: 隐藏控制面板
       enable_controls: 显示控制面板

--- a/packages/editor/src/locales/zh-CN.yaml
+++ b/packages/editor/src/locales/zh-CN.yaml
@@ -49,6 +49,7 @@ editor:
       large_size: 大尺寸
       restore_size: 恢复原始尺寸
       edit_link: 修改链接
+      edit_alt: 修改图片alt属性
     video:
       disable_controls: 隐藏控制面板
       enable_controls: 显示控制面板
@@ -99,6 +100,7 @@ editor:
       open_link: 打开链接
     placeholder:
       link_input: 输入链接，按回车确定
+      alt_input: 输入图片alt属性值,然后回车确认
     button:
       new_line: 换行
       delete: 删除


### PR DESCRIPTION
为富文本编辑器添加修改alt属性的按钮：
![image](https://github.com/halo-sigs/richtext-editor/assets/110895612/c4fd921a-01ef-47e3-8ac9-d29748211efe)
点击按钮出现input框，供用户添加alt属性
![image](https://github.com/halo-sigs/richtext-editor/assets/110895612/d865d579-ba1d-4911-99f2-15cd63ec28ee)
Fixes https://github.com/halo-dev/halo/issues/4397

```release-note
图片支持修改 alt 属性。
```