### PR TITLE
chore: using the mod-a shortcut key in the code block will only select the code

### DIFF
--- a/packages/editor/src/extensions/code-block/code-block.ts
+++ b/packages/editor/src/extensions/code-block/code-block.ts
@@ -4,6 +4,7 @@ import {
   type Range,
   type CommandProps,
   isActive,
+  findParentNode,
 } from "@tiptap/vue-3";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import type { CodeBlockLowlightOptions } from "@tiptap/extension-code-block-lowlight";
@@ -15,7 +16,6 @@ import { i18n } from "@/locales";
 import ToolboxItem from "@/components/toolbox/ToolboxItem.vue";
 import {
   EditorState,
-  NodeSelection,
   TextSelection,
   type Transaction,
 } from "prosemirror-state";
@@ -123,6 +123,24 @@ export default CodeBlockLowlight.extend<
           return this.editor.chain().focus().codeOutdent().run();
         }
         return;
+      },
+      "Mod-a": () => {
+        if (this.editor.isActive("codeBlock")) {
+          const { tr, selection } = this.editor.state;
+          const codeBlack = findParentNode(
+            (node) => node.type.name === CodeBlockLowlight.name
+          )(selection);
+          if (!codeBlack) return;
+          const head = codeBlack.start;
+          const anchor = codeBlack.start + codeBlack.node.nodeSize - 1;
+          const $head = tr.doc.resolve(head);
+          const $anchor = tr.doc.resolve(anchor);
+          this.editor.view.dispatch(
+            tr.setSelection(new TextSelection($head, $anchor))
+          );
+          return true;
+        }
+        return false;
       },
     };
   },


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

在代码块中使用 ctrl + a / command + a 时，只会选中当前代码块中的内容而不是编辑器的全部内容

#### How to test it?

1. 创建一个代码块并编辑一些文本。
2. 在代码块中按 ctrl + a / command + a，查看选中的是否仅为代码块中的文本

#### Which issue(s) this PR fixes:

Ref https://github.com/halo-dev/halo/issues/4447
Ref https://github.com/halo-dev/halo/issues/4232

#### Does this PR introduce a user-facing change?
```release-note
在代码块中使用全选快捷键将只会选中代码
```
