### PR TITLE
fix: resolve the issue of not maintaining aspect ratio when dragging images

### DIFF
--- a/packages/editor/src/extensions/image/BubbleItemImageSize.vue
+++ b/packages/editor/src/extensions/image/BubbleItemImageSize.vue
@@ -82,7 +82,6 @@ const reuseResizeObserver = () => {
       if (!node) {
         return;
       }
-      console.log(w + "px", w * imgScale.value + "px");
       props.editor
         .chain()
         .updateAttributes(Image.name, {

--- a/packages/editor/src/extensions/image/BubbleItemImageSize.vue
+++ b/packages/editor/src/extensions/image/BubbleItemImageSize.vue
@@ -78,6 +78,11 @@ const reuseResizeObserver = () => {
         init = false;
         return;
       }
+      const node = props.editor.view.nodeDOM(props.editor.state.selection.from);
+      if (!node) {
+        return;
+      }
+      console.log(w + "px", w * imgScale.value + "px");
       props.editor
         .chain()
         .updateAttributes(Image.name, {

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -3,7 +3,9 @@ import { i18n } from "@/locales";
 import { Editor, Node, NodeViewWrapper } from "@tiptap/vue-3";
 import type { Node as ProseMirrorNode } from "prosemirror-model";
 import type { Decoration } from "prosemirror-view";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { useResizeObserver } from "@vueuse/core";
+
 const props = defineProps<{
   editor: Editor;
   node: ProseMirrorNode;
@@ -40,9 +42,25 @@ function handleSetFocus() {
 }
 
 const inputRef = ref();
+const resizeRef = ref();
+
+const init = ref(true);
+
 onMounted(() => {
   if (!src.value) {
     inputRef.value.focus();
+  } else {
+    useResizeObserver(resizeRef.value, (entries) => {
+      const entry = entries[0];
+      const { height } = entry.contentRect;
+      if (height == 0) {
+        return;
+      }
+      if (!props.selected && !init.value) {
+        handleSetFocus();
+      }
+      init.value = false;
+    });
   }
 });
 </script>

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -3,7 +3,7 @@ import { i18n } from "@/locales";
 import { Editor, Node, NodeViewWrapper } from "@tiptap/vue-3";
 import type { Node as ProseMirrorNode } from "prosemirror-model";
 import type { Decoration } from "prosemirror-view";
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useResizeObserver } from "@vueuse/core";
 
 const props = defineProps<{
@@ -43,7 +43,6 @@ function handleSetFocus() {
 
 const inputRef = ref();
 const resizeRef = ref();
-
 const init = ref(true);
 
 onMounted(() => {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

为图片增加监听，当其触发 resize 监听时，自动选择当前触发的 node 节点。解决当未选中图片进行拖拽时，图片无法保持纵横比的问题。

#### How to test it?

1. 在编辑器内增加一个图片元素节点
2. 刷新一下编辑器
3. 在不点击选中图片元素的情况下，拖拽图片右下角，查看图片是否能保持纵横比。

#### Does this PR introduce a user-facing change?
```release-note
修复未选中图片元素时，拖拽图片无法保持纵横比的问题。
```
