### PR TITLE
fix: resolve the issue of incomplete coverage of text highlight

### DIFF
--- a/packages/editor/src/extensions/highlight/index.ts
+++ b/packages/editor/src/extensions/highlight/index.ts
@@ -14,20 +14,10 @@ const Highlight = TiptapHighlight.extend<ExtensionOptions & HighlightOptions>({
     }
 
     return {
-      color: {
-        default: null,
-        parseHTML: (element) =>
-          element.getAttribute("data-color") || element.style.backgroundColor,
-        renderHTML: (attributes) => {
-          if (!attributes.color) {
-            return {};
-          }
-
-          return {
-            "data-color": attributes.color,
-            style: `background-color: ${attributes.color}; color: inherit; display: inline-block;`,
-          };
-        },
+      ...this.parent?.(),
+      style: {
+        default: "display: inline-block;",
+        parseHTML: (element) => element.getAttribute("style"),
       },
     };
   },

--- a/packages/editor/src/extensions/highlight/index.ts
+++ b/packages/editor/src/extensions/highlight/index.ts
@@ -8,6 +8,29 @@ import type { ExtensionOptions } from "@/types";
 import HighlightToolbarItem from "./HighlightToolbarItem.vue";
 
 const Highlight = TiptapHighlight.extend<ExtensionOptions & HighlightOptions>({
+  addAttributes() {
+    if (!this.options.multicolor) {
+      return {};
+    }
+
+    return {
+      color: {
+        default: null,
+        parseHTML: (element) =>
+          element.getAttribute("data-color") || element.style.backgroundColor,
+        renderHTML: (attributes) => {
+          if (!attributes.color) {
+            return {};
+          }
+
+          return {
+            "data-color": attributes.color,
+            style: `background-color: ${attributes.color}; color: inherit; display: inline-block;`,
+          };
+        },
+      },
+    };
+  },
   addOptions() {
     return {
       ...this.parent?.(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

为高亮 html 设置 `display: inline-block` 样式，解决由于设置了文本大小之后，再设置个高亮所导致高亮显示不完全的问题。

#### How to test it?

1. 为文本设置大小
2. 为文本设置高亮
3. 查看高亮背景是否展示完全

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4653

#### Does this PR introduce a user-facing change?
```release-note
解决文本高亮显示不完全的问题
```
