### PR TITLE
fix: can not generate d.ts file after build

### DIFF
--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -18,6 +18,7 @@ export default ({ mode }: { mode: string }) => {
       }),
       isProduction &&
         dts({
+          tsconfigPath: "./tsconfig.app.json",
           entryRoot: "./src",
           outDir: "./dist",
           insertTypesEntry: true,


### PR DESCRIPTION
修复编译之后没有生成 d.ts 类型文件的问题。

<img width="449" alt="image" src="https://github.com/halo-sigs/richtext-editor/assets/21301288/a7c31346-5358-469e-9efc-aade36216030">

/kind bug

```release-note
None
```