### PR TITLE
fix: resolve the issue of the editor menu changing with page scrolling

### DIFF
--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -145,13 +145,7 @@ const locale = useLocalStorage("locale", "zh-CN");
 </script>
 
 <template>
-  <div>
-    <select v-model="locale">
-      <option v-for="(item, index) in locales" :key="index" :value="item.code">
-        {{ item.label }}
-      </option>
-    </select>
+  <div style="height: 100vh" class="flex">
+    <RichTextEditor v-if="editor" :editor="editor" :locale="locale" />
   </div>
-
-  <RichTextEditor v-if="editor" :editor="editor" :locale="locale" />
 </template>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "packages:dev": "pnpm --filter './packages/**' dev",
     "packages:build": "pnpm --filter './packages/**' build",
+    "packages:link": "pnpm link -global --dir ./packages/**",
     "packages:release": "pnpm --filter './packages/**' release",
     "example:dev": "pnpm --filter './example/' run dev",
     "example:build": "pnpm --filter './example/' run build",

--- a/packages/editor/src/components/Editor.vue
+++ b/packages/editor/src/components/Editor.vue
@@ -29,14 +29,14 @@ watch(
   },
   {
     immediate: true,
-  }
+  },
 );
 </script>
 <template>
   <div v-if="editor" class="halo-rich-text-editor">
     <editor-bubble-menu :editor="editor" />
     <editor-header :editor="editor" />
-    <div class="h-full flex flex-row w-full">
+    <div class="h-full flex flex-row w-full overflow-auto relative">
       <editor-content
         :editor="editor"
         :style="contentStyles"

--- a/packages/editor/src/components/Editor.vue
+++ b/packages/editor/src/components/Editor.vue
@@ -36,14 +36,18 @@ watch(
   <div v-if="editor" class="halo-rich-text-editor">
     <editor-bubble-menu :editor="editor" />
     <editor-header :editor="editor" />
-    <div class="h-full flex flex-row w-full overflow-auto relative">
-      <editor-content
-        :editor="editor"
-        :style="contentStyles"
-        class="editor-content markdown-body"
-        :class="{ 'sm:!w-[calc(100%-18rem)]': $slots.extra }"
-      />
-      <div v-if="$slots.extra" class="h-full hidden sm:!block w-72">
+    <div class="h-full flex flex-row w-full">
+      <div class="overflow-y-auto overflow-x-hidden flex-1 relative bg-white">
+        <editor-content
+          :editor="editor"
+          :style="contentStyles"
+          class="editor-content markdown-body"
+        />
+      </div>
+      <div
+        v-if="$slots.extra"
+        class="h-full hidden sm:!block w-72 flex-shrink-0"
+      >
         <slot name="extra"></slot>
       </div>
     </div>

--- a/packages/editor/src/components/bubble/BubbleMenuPlugin.ts
+++ b/packages/editor/src/components/bubble/BubbleMenuPlugin.ts
@@ -156,6 +156,19 @@ export class BubbleMenuView {
       placement: "bottom-start",
       hideOnClick: "toggle",
       plugins: [sticky],
+      popperOptions: {
+        modifiers: [
+          {
+            name: "customWidth",
+            enabled: true,
+            phase: "beforeWrite",
+            requires: ["computeStyles"],
+            fn({ state }) {
+              state.styles.popper.maxWidth = "98%";
+            },
+          },
+        ],
+      },
       ...Object.assign(
         {
           zIndex: 999,
@@ -167,7 +180,7 @@ export class BubbleMenuView {
             : {}),
           fixed: true,
         },
-        this.tippyOptions
+        this.tippyOptions,
       ),
     });
 
@@ -177,7 +190,7 @@ export class BubbleMenuView {
         "blur",
         (event) => {
           this.blurHandler({ event });
-        }
+        },
       );
     }
   }
@@ -238,7 +251,7 @@ export class BubbleMenuView {
       (instance) =>
         instance.id !== this.tippy?.id &&
         instance.popperInstance &&
-        instance.popperInstance.state
+        instance.popperInstance.state,
     );
     const offset = this.tippyOptions?.offset as [number, number];
     const offsetX = offset?.[0] ?? 0;
@@ -296,7 +309,7 @@ export class BubbleMenuView {
 
   addActiveBubbleMenu = () => {
     const idx = ACTIVE_BUBBLE_MENUS.findIndex(
-      (instance) => instance?.id === this.tippy?.id
+      (instance) => instance?.id === this.tippy?.id,
     );
     if (idx < 0) {
       ACTIVE_BUBBLE_MENUS.push(this.tippy as Instance);
@@ -305,7 +318,7 @@ export class BubbleMenuView {
 
   removeActiveBubbleMenu = () => {
     const idx = ACTIVE_BUBBLE_MENUS.findIndex(
-      (instance) => instance?.id === this.tippy?.id
+      (instance) => instance?.id === this.tippy?.id,
     );
     if (idx > -1) {
       ACTIVE_BUBBLE_MENUS.splice(idx, 1);

--- a/packages/editor/src/styles/base.scss
+++ b/packages/editor/src/styles/base.scss
@@ -11,15 +11,12 @@
   }
 
   .editor-content {
-    height: 100%;
     width: 100%;
     position: relative;
 
     .ProseMirror {
-      height: 100%;
-      overflow: auto;
       outline: none !important;
-      padding: $editorVerticalPadding;
+      padding: $editorVerticalPadding 20px;
 
       p {
         margin-top: 0.75em;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

解决页面具有固定高度之后，菜单会跟随页面的滚动而滚动的问题。

并增加 `pnpm link` 使其可在本地与 console 进行调试

#### How to test it?

查看冒泡菜单是否会跟随页面滚动

#### Does this PR introduce a user-facing change?
```release-note
None
```
