### PR TITLE
fix: resolve the issue of the table tooltip being unclickable after integrating the editor

### DIFF
--- a/packages/editor/src/styles/base.scss
+++ b/packages/editor/src/styles/base.scss
@@ -88,6 +88,10 @@
       }
     }
   }
+
+  .v-popper--theme-tooltip {
+    pointer-events: all;
+  }
 }
 
 .v-popper--theme-editor-block-dropdown {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

解决由于样式冲突导致集成编辑器至 console 后无法点击表格的行列插入功能。

#### How to test it?

需要链接编辑器至 console 后进行测试。

链接方式：
1. 在编辑器根目录下执行 `pnpm packages:link`
2. 在 console 根目录下执行 `pnpm link:editor`

打开 console 下的编辑器，查看是否可以点击到表格的行列插入功能

#### Which issue(s) this PR fixes:

Fixes #60 

#### Does this PR introduce a user-facing change?
```release-note
修复表格行列插入功能无法点击到的问题
```
