### PR TITLE
fix: refactor imports NodeViewWrapper in iframe and image

### DIFF
--- a/packages/editor/src/extensions/iframe/IframeView.vue
+++ b/packages/editor/src/extensions/iframe/IframeView.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { Node as ProseMirrorNode, Decoration } from "@/tiptap/pm";
-import type { Editor, Node, NodeViewWrapper } from "@/tiptap/vue-3";
+import type { Editor, Node } from "@/tiptap/vue-3";
+import { NodeViewWrapper } from "@/tiptap/vue-3";
 import { computed, onMounted, ref } from "vue";
 import { i18n } from "@/locales";
 

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { i18n } from "@/locales";
-import type { Editor, Node, NodeViewWrapper } from "@/tiptap/vue-3";
+import type { Editor, Node } from "@/tiptap/vue-3";
+import { NodeViewWrapper } from "@/tiptap/vue-3";
 import type { Node as ProseMirrorNode, Decoration } from "@/tiptap/pm";
 import { computed, onMounted, ref } from "vue";
 import { useResizeObserver } from "@vueuse/core";


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

重新导入在 `image` 及 `iframe` 中的 NodeViewWrapper，在 PR #67  时，误操作导致将其导出为了 type。

#### Which issue(s) this PR fixes:

Fixes #68 

#### Does this PR introduce a user-facing change?
```release-note
None
```
