### PR TITLE
fix: refactor the bubble menu container to resolve overlay issues

### DIFF
--- a/packages/editor/src/components/Editor.vue
+++ b/packages/editor/src/components/Editor.vue
@@ -20,6 +20,11 @@ const props = defineProps({
     required: false,
     default: "zh-CN",
   },
+  bubbleElement: {
+    type: String || (Object as PropType<HTMLElement>),
+    required: false,
+    default: ".halo-rich-text-editor",
+  },
 });
 
 watch(
@@ -34,7 +39,7 @@ watch(
 </script>
 <template>
   <div v-if="editor" class="halo-rich-text-editor">
-    <editor-bubble-menu :editor="editor" />
+    <editor-bubble-menu :editor="editor" :bubble-element="bubbleElement" />
     <editor-header :editor="editor" />
     <div class="h-full flex flex-row w-full">
       <div class="overflow-y-auto overflow-x-hidden flex-1 relative bg-white">

--- a/packages/editor/src/components/EditorBubbleMenu.vue
+++ b/packages/editor/src/components/EditorBubbleMenu.vue
@@ -11,6 +11,10 @@ const props = defineProps({
     type: Object as PropType<Editor>,
     required: true,
   },
+  bubbleElement: {
+    type: String || (Object as PropType<HTMLElement>),
+    required: true,
+  },
 });
 
 const getBubbleMenuFromExtensions = () => {
@@ -62,6 +66,7 @@ const shouldShow = (
     :key="index"
     :plugin-key="bubbleMenu?.pluginKey"
     :should-show="(prop) => shouldShow(prop, bubbleMenu)"
+    :bubble-element="bubbleElement"
     :editor="editor"
     :tippy-options="{
       maxWidth: '100%',

--- a/packages/editor/src/components/bubble/BubbleMenu.vue
+++ b/packages/editor/src/components/bubble/BubbleMenu.vue
@@ -16,6 +16,11 @@ const props = defineProps({
     required: true,
   },
 
+  bubbleElement: {
+    type: [String, Object] as PropType<BubbleMenuPluginProps["bubbleElement"]>,
+    required: true,
+  },
+
   tippyOptions: {
     type: Object as PropType<BubbleMenuPluginProps["tippyOptions"]>,
     default: () => ({}),
@@ -45,6 +50,7 @@ const root = ref<HTMLElement | null>(null);
 onMounted(() => {
   const {
     editor,
+    bubbleElement,
     pluginKey,
     shouldShow,
     tippyOptions,
@@ -55,6 +61,7 @@ onMounted(() => {
   editor.registerPlugin(
     BubbleMenuPlugin({
       editor,
+      bubbleElement,
       element: root.value as HTMLElement,
       pluginKey,
       shouldShow,

--- a/packages/editor/src/components/bubble/BubbleMenuPlugin.ts
+++ b/packages/editor/src/components/bubble/BubbleMenuPlugin.ts
@@ -14,6 +14,7 @@ export interface TippyOptionProps extends Props {
 export interface BubbleMenuPluginProps {
   pluginKey: PluginKey | string;
   editor: Editor;
+  bubbleElement: string | HTMLElement;
   element: HTMLElement;
   tippyOptions?: Partial<TippyOptionProps>;
   updateDelay?: number;
@@ -40,6 +41,8 @@ const ACTIVE_BUBBLE_MENUS: Instance[] = [];
 
 export class BubbleMenuView {
   public editor: Editor;
+
+  public bubbleMenuContainer: HTMLElement;
 
   public element: HTMLElement;
 
@@ -79,6 +82,7 @@ export class BubbleMenuView {
 
   constructor({
     editor,
+    bubbleElement,
     element,
     view,
     tippyOptions = {},
@@ -104,6 +108,10 @@ export class BubbleMenuView {
     // Detaches menu content from its current parent
     this.element.remove();
     this.element.style.visibility = "visible";
+    this.bubbleMenuContainer =
+      (typeof bubbleElement === "string"
+        ? (document.querySelector(bubbleElement) as HTMLElement)
+        : bubbleElement) || editor.options.element;
   }
 
   mousedownHandler = () => {
@@ -141,14 +149,11 @@ export class BubbleMenuView {
   };
 
   createTooltip() {
-    const { element: editorElement } = this.editor.options;
-    const editorIsAttached = !!editorElement.parentElement;
-
-    if (this.tippy || !editorIsAttached) {
+    if (this.tippy) {
       return;
     }
 
-    this.tippy = tippy(editorElement, {
+    this.tippy = tippy(this.bubbleMenuContainer, {
       getReferenceClientRect: null,
       content: this.element,
       interactive: true,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

重构了冒泡菜单的父容器定位，由之前默认的 `editor.option.element` 即富文本编辑器自身变为了可由 editor 提供的任意 class 或 Element。默认值为 `.halo-rich-text-editor`。

这将可以使冒泡菜单不局限于编辑器自身的内容高度，防止被祖先节点裁剪

#### How to test it?

输入超过一屏宽度的内容，按 `MOD + A` 全选，查看冒泡菜单是否被顶部菜单遮挡。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4869

#### Does this PR introduce a user-facing change?
```release-note
解决冒泡菜单可能会遮挡的问题
```
