### PR TITLE
fix: resolve the issue of inline block elements not fully occupying the width

### DIFF
--- a/packages/editor/src/extensions/audio/AudioView.vue
+++ b/packages/editor/src/extensions/audio/AudioView.vue
@@ -47,7 +47,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <node-view-wrapper as="div" class="inline-block" :class="{ 'w-full': !src }">
+  <node-view-wrapper as="div" class="inline-block w-full">
     <div
       class="inline-block overflow-hidden transition-all text-center relative h-full w-full"
     >

--- a/packages/editor/src/extensions/iframe/IframeView.vue
+++ b/packages/editor/src/extensions/iframe/IframeView.vue
@@ -42,7 +42,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <node-view-wrapper as="div" class="inline-block" :class="{ 'w-full': !src }">
+  <node-view-wrapper as="div" class="inline-block w-full">
     <div
       class="inline-block overflow-hidden transition-all text-center relative h-full"
       :style="{

--- a/packages/editor/src/extensions/image/ImageView.vue
+++ b/packages/editor/src/extensions/image/ImageView.vue
@@ -73,7 +73,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <node-view-wrapper as="div" class="inline-block" :class="{ 'w-full': !src }">
+  <node-view-wrapper as="div" class="inline-block w-full">
     <div v-if="!src" class="p-1.5 w-full">
       <input
         ref="inputRef"

--- a/packages/editor/src/extensions/video/VideoView.vue
+++ b/packages/editor/src/extensions/video/VideoView.vue
@@ -51,7 +51,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <node-view-wrapper as="div" class="inline-block" :class="{ 'w-full': !src }">
+  <node-view-wrapper as="div" class="inline-block w-full">
     <div
       class="inline-block overflow-hidden transition-all text-center relative h-full"
       :style="{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

将行内块元素（iframe, video, image, audio）默认宽度设置为 100%。用以解决设置为 100% 是宽度不准确的问题。

#### How to test it?

新增一个行内块元素，点击设置其大小为`桌面端大小`，查看是否占满编辑器宽度。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/4868

#### Does this PR introduce a user-facing change?
```release-note
解决行内块元素宽度设置不准确的问题
```
